### PR TITLE
fix(blog): correct authorization logic in removeComment

### DIFF
--- a/src/controllers/BlogController.js
+++ b/src/controllers/BlogController.js
@@ -221,7 +221,7 @@ const user = await User.findById(req.id);
   console.log("Commenter ID:", comment.commentedBy);
   console.log("Blog Author ID:", comment.blogId.author);
   console.log("Requesting User ID:", req.id);
-  if (!isCommenter || !isBlogAuthor) {
+  if (!isCommenter && !isBlogAuthor) {
       if (user.superadmin) {
         await Comment.deleteMany({ replyTo: comment._id });
           await Comment.findByIdAndDelete(_id);


### PR DESCRIPTION
Issue(#105): Bug Fix: removeComment Authorization Logic

The condition `!isCommenter || !isBlogAuthor` incorrectly blocked 
commenters from deleting their own comments unless they were also 
the blog author. Changed to `!isCommenter && !isBlogAuthor` so 
either the commenter or blog author can delete.

- Proof
- Screenshot 1: User A adds a comment
- Screenshot 2: User B attempts to delete → 403 Forbidden  
- Screenshot 3: User A deletes their own comment → 200 OK


<img width="1825" height="797" alt="Screenshot 2026-05-04 230358" src="https://github.com/user-attachments/assets/0582436f-910b-4f8c-9220-ba3619c0fefa" />

<img width="1824" height="839" alt="Screenshot 2026-05-04 230318" src="https://github.com/user-attachments/assets/d2eab595-d3b5-49ef-ad91-85938c61d7ac" />

<img width="1827" height="742" alt="Screenshot 2026-05-04 230541" src="https://github.com/user-attachments/assets/ff998841-c67b-4772-9fdd-98d0391b6d18" />

