### PR TITLE
fix(rate-limit): track limits per IP instead of globally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@ GMAIL_USER =
 # DATABASE_URL="postgresql://gdgc_user:gdgc_password@postgres:5432/gdgc_db?schema=public"
 CRYPTO_KEY =  
 # For crypto key use randomBytes from crypto lib. to generate a 32 bytes key then convert it to hex using toStirng('hex')
+JWT_SECRET=your-jwt-secret-here

--- a/src/middleware/RateLimitter.js
+++ b/src/middleware/RateLimitter.js
@@ -4,6 +4,7 @@ import rateLimit from 'express-rate-limit';
 export const defaultLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     limit: 100,
+    keyGenerator: (req) => req.ip,
     standardHeaders: 'draft-8',
     legacyHeaders: false,
     message: {
@@ -18,6 +19,7 @@ export const defaultLimiter = rateLimit({
 export const strictLimiter = rateLimit({    
     windowMs: 1 * 60 * 1000, // 1 minute
     limit: 5,
+    keyGenerator: (req) => req.ip,
     standardHeaders: 'draft-8',
     legacyHeaders: false,
     message: {
@@ -30,6 +32,7 @@ export const strictLimiter = rateLimit({
 export const formLimiter = rateLimit({
     windowMs: 1 * 60 * 1000, // 1 minute
     limit: 5,
+    keyGenerator: (req) => req.ip,
     standardHeaders: 'draft-8',
     legacyHeaders: false,
     message: {

--- a/src/routes/blog.js
+++ b/src/routes/blog.js
@@ -2,7 +2,9 @@ import express from "express";
 import {BlogController} from "../controllers/BlogController.js";
 import { VerifyToken } from "../middleware/AuthMiddleware.js";
 import SuperAdminMiddleware from "../middleware/SuperAdminMiddleware.js";
+import { defaultLimiter } from "../middleware/RateLimitter.js";
 export const blogRouter = express.Router()
+blogRouter.use(defaultLimiter);
 
 
 blogRouter.route('/get-blogs').get(BlogController.getBlogs)


### PR DESCRIPTION
## Fix: Per-IP Rate Limiting

### Problem
The existing rate limiters in `src/middleware/RateLimitter.js` had no
`keyGenerator`, so `express-rate-limit` fell back to a single global
counter shared across all users. If one user sent enough requests to
hit the limit, every other user would get blocked too, even if they
had made zero requests.

### What I changed

**`src/middleware/RateLimitter.js`**  
Added `keyGenerator: (req) => req.ip` to `defaultLimiter`,
`strictLimiter`, and `formLimiter`. Each IP address now gets its own
independent counter tracked in memory. The `rateLimiter` factory
function was not modified.

**`src/routes/blog.js`**  
Applied `defaultLimiter` as router-level middleware so all blog
endpoints are covered.

**`.env.example`**  
Added the missing `JWT_SECRET` variable, it was actively used in
`AuthMiddleware.js` but not documented, which would confuse anyone
setting up the project from scratch.

### How it works
`express-rate-limit` uses an in-memory store by default. With
`keyGenerator: (req) => req.ip`, each unique IP gets its own bucket.
One user hitting the limit only affects themselves.

Closes #84
